### PR TITLE
change sinatra require to be compatible with apps using Resque

### DIFF
--- a/lib/raddocs.rb
+++ b/lib/raddocs.rb
@@ -1,4 +1,4 @@
-require 'sinatra'
+require 'sinatra/base'
 require 'json'
 require 'raddocs/configuration'
 require 'raddocs/app'


### PR DESCRIPTION
Doing a require 'sinatra' includes Sinatra::Delegate, which gets included in the open (onto Kernel). Sinatra::Delegate delegates some methods which breaks stuff like Resque's redis.get calls.
The only change needed is to require 'sinatra/base' instead.
