### PR TITLE
Show "required" on example parameter.

### DIFF
--- a/lib/views/example.haml
+++ b/lib/views/example.haml
@@ -42,7 +42,7 @@
       %tbody
         - example["parameters"].each do |param|
           %tr.parameter
-            %td
+            %td{class: ("required" if param["required"])}
               %span.name= param["name"]
             %td
               %span.description= param["description"]


### PR DESCRIPTION
Porting this over from the rspec_api_documentation template.
