### PR TITLE
html escape response header values

### DIFF
--- a/lib/views/example.haml
+++ b/lib/views/example.haml
@@ -95,7 +95,7 @@
               :ruby
                 # There are unwanted indents if this was a simple each and output in haml
                 headers = request["response_headers"].map do |header, value|
-                  "#{header}: #{value}"
+                  "#{header}: #{html_escape(value)}"
                   end
               :preserve
                 #{headers.join("\n")}


### PR DESCRIPTION
this correctly handles a case like `Link: <http://api.test.example.org/applications?page=0&per_page=20>; rel="last"`
