### PR TITLE
Use "Content-Type" from request/response headers

### DIFF
--- a/lib/views/example.haml
+++ b/lib/views/example.haml
@@ -87,7 +87,7 @@
       - if request["request_body"]
         %section.body
           %h4 Body
-          .content{ "data-content-type" => request["request_content_type"] }
+          .content{ "data-content-type" => request["request_headers"]["Content-Type"] }
             %textarea
               :preserve
                 #{request["request_body"]}
@@ -119,7 +119,7 @@
           - if request["response_body"]
             %section.body
               %h4 Body
-              .content{ "data-content-type" => request["response_content_type"] }
+              .content{ "data-content-type" => request["response_headers"]["Content-Type"] }
                 %textarea
                   :preserve
                     #{request["response_body"]}

--- a/spec/fixtures/orders/creating_an_order.json
+++ b/spec/fixtures/orders/creating_an_order.json
@@ -36,7 +36,6 @@
         "Cookie": ""
       },
       "request_query_parameters": {},
-      "request_content_type": "application/json",
       "response_status": 201,
       "response_status_text": "Created",
       "response_body": "{\"email\":\"email@example.com\",\"name\":\"Order 1\",\"paid\":true}",
@@ -49,7 +48,6 @@
         "X-Runtime": "0.006262",
         "Content-Length": "58"
       },
-      "response_content_type": "application/json; charset=utf-8",
       "curl": "curl \"http://localhost:3000/orders\" -d \"{\"order\":{\"name\":\"Order 1\",\"paid\":true,\"email\":\"email@example.com\"}}\" -X POST -H \"Accept: application/json\" -H \"Content-Type: application/json\" -H \"Host: example.org\" -H \"Cookie: \""
     },
     {
@@ -63,7 +61,6 @@
         "Cookie": ""
       },
       "request_query_parameters": {},
-      "request_content_type": "application/json",
       "response_status": 200,
       "response_status_text": "OK",
       "response_body": "{\"email\":\"email@example.com\",\"name\":\"Order 1\",\"paid\":true}",
@@ -75,7 +72,6 @@
         "X-Runtime": "0.004752",
         "Content-Length": "58"
       },
-      "response_content_type": "application/json; charset=utf-8",
       "curl": "curl \"http://localhost:3000/orders/9\" -X GET -H \"Accept: application/json\" -H \"Content-Type: application/json\" -H \"Host: example.org\" -H \"Cookie: \""
     }
   ]


### PR DESCRIPTION
It seems unnecessary to use "request_content_type" and "response_content_type"
when those data are already included in the respective headers dictionaries.

I don't think it's useful to have these extra keys be part of the expected JSON
payload. Indeed, http_spec does not generate them, although RAD does.

This change continues to work with RAD, because it includes the Content-Type
header, but also works with http_spec.

I could have changed http_spec to include these keys, but I think this is a
better fix.
