### PR TITLE
Use API name for html title

### DIFF
--- a/lib/views/layout.haml
+++ b/lib/views/layout.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %title Raddocs
+    %title= api_name
     - css_files.each do |file|
       %link{:rel => "stylesheet", :href => file}
     %script(src="#{url_location}/js/jquery-1-7-2.js")

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -5,6 +5,10 @@ describe 'Index' do
     visit "/"
   end
 
+  it "should have the api name as the title" do
+    find("head title").should have_content("Raddocs Test")
+  end
+
   it "should have the api name" do
     find("h1").should have_content("Raddocs Test")
   end


### PR DESCRIPTION
Instead of Raddocs, use the api_name config value as the value of the
html head title
