### PR TITLE
Don't show headers on example if there aren't any

### DIFF
--- a/lib/raddocs/models.rb
+++ b/lib/raddocs/models.rb
@@ -258,6 +258,11 @@ module Raddocs
       !@request_body.nil?
     end
 
+    # @return [Boolean] true if request headers are present
+    def request_headers?
+      request_headers.length > 0
+    end
+
     # Request headers must be set
     # @return [String] Content type of the request
     def request_content_type
@@ -284,6 +289,11 @@ module Raddocs
     # @return [Boolean] true if response body is present
     def response_body?
       !@response_body.nil?
+    end
+
+    # @return [Boolean] true if response headers are present
+    def response_headers?
+      response_headers.length > 0
     end
 
     # Response headers must be set

--- a/lib/views/example.haml
+++ b/lib/views/example.haml
@@ -85,11 +85,12 @@
     .request{ :id => "request-#{index}" }
       %h3 Request
 
-      %section.headers
-        %h4 Headers
-        %pre.headers
-          :preserve
-            #{request.request_headers}
+      - if request.response_headers?
+        %section.headers
+          %h4 Headers
+          %pre.headers
+            :preserve
+              #{request.request_headers}
 
       %section.route
         %h4 Route
@@ -118,11 +119,12 @@
         .response
           %h3 Response
 
-          %section.headers
-            %h4 Headers
-            %pre.headers
-              :preserve
-                #{request.response_headers}
+          - if request.response_headers?
+            %section.headers
+              %h4 Headers
+              %pre.headers
+                :preserve
+                  #{request.response_headers}
 
           %section.status
             %h4 Status


### PR DESCRIPTION
This removes an ugly grey box when there aren't any headers to show.