### PR TITLE
Optional guides.yml

### DIFF
--- a/lib/raddocs/app.rb
+++ b/lib/raddocs/app.rb
@@ -113,9 +113,14 @@ module Raddocs
       end
 
       def guides
-        YAML.load(File.read(File.join(guides_dir, "guides.yml"))).map do |guide_hash|
+        return [] unless File.exist?(guides_index)
+        YAML.load(File.read(guides_index)).map do |guide_hash|
           Guide.new(guide_hash)
         end
+      end
+
+      def guides_index
+        File.join guides_dir, "guides.yml"
       end
 
       def guides_dir


### PR DESCRIPTION
We don't have guides and it looks like the newest version of raddocs expects a `guides.yml` to exist. This PR amends the code to return an empty array if it doesn't (instead of throwing an exception).