### PR TITLE
Move highlighting javascript out of haml and into its own file

### DIFF
--- a/lib/public/js/example.js
+++ b/lib/public/js/example.js
@@ -1,0 +1,24 @@
+function mirror(textarea, contentType, options) {
+  $textarea = $(textarea);
+  if ($textarea.val() != '') {
+    if(contentType.indexOf('json') >= 0) {
+      $textarea.val(JSON.stringify(JSON.parse($textarea.val()), undefined, 2));
+      options.json = true;
+      options.mode = 'javascript';
+    } else if (contentType.indexOf('javascript') >= 0) {
+      options.mode = 'javascript';
+    } else if (contentType.indexOf('xml') >= 0) {
+      options.mode = 'xml';
+    } else {
+      options.mode = 'htmlmixed';
+    }
+  }
+  return CodeMirror.fromTextArea(textarea, options);
+};
+
+$(function(){
+  $(".request .body .content").each(function(i, el) {
+    el = $(el);
+    mirror(el.find("textarea")[0], el.data("content-type"), { "readOnly": true, "lineNumbers": true });
+  });
+});

--- a/lib/views/example.haml
+++ b/lib/views/example.haml
@@ -3,31 +3,7 @@
     = haml :nav, locals: { index: index, api_name: api_name }
 
   .span10.main
-    :javascript
-      function mirror(textarea, contentType, options) {
-        $textarea = $(textarea);
-        if ($textarea.val() != '') {
-          if(contentType.indexOf('json') >= 0) {
-            $textarea.val(JSON.stringify(JSON.parse($textarea.val()), undefined, 2));
-            options.json = true;
-            options.mode = 'javascript';
-          } else if (contentType.indexOf('javascript') >= 0) {
-            options.mode = 'javascript';
-          } else if (contentType.indexOf('xml') >= 0) {
-            options.mode = 'xml';
-          } else {
-            options.mode = 'htmlmixed';
-          }
-        }
-        return CodeMirror.fromTextArea(textarea, options);
-      };
-
-      $(function(){
-        $(".request .body .content").each(function(i, el) {
-          el = $(el);
-          mirror(el.find("textarea")[0], el.data("content-type"), { "readOnly": true, "lineNumbers": true });
-        });
-      });
+    %script(src="#{url_location}/js/example.js")
 
     .nav-bar
       = link_to "&laquo; Back to Index", "/"


### PR DESCRIPTION
Not doing this is sort of bad behavior for such a large block of code and also breaks down in modern CSP-ey environs.

-----

Came to this solution when trying to solve for https://github.com/smartlogic/raddocs/issues/41

-----

Another variant of this was integrating Rails CSP w nonce stuff into the raddocs env. It looked like this but didn't have optionality or error handling yet, so this is just an incomplete WIP that might be needed some time.
```
> cat nonce.patch
diff --git a/lib/public/js/example.js b/lib/public/js/example.js
new file mode 100644
index 0000000..d44cfcd
--- /dev/null
+++ b/lib/public/js/example.js
@@ -0,0 +1,24 @@
+function mirror(textarea, contentType, options) {
+  $textarea = $(textarea);
+  if ($textarea.val() != '') {
+    if(contentType.indexOf('json') >= 0) {
+      $textarea.val(JSON.stringify(JSON.parse($textarea.val()), undefined, 2));
+      options.json = true;
+      options.mode = 'javascript';
+    } else if (contentType.indexOf('javascript') >= 0) {
+      options.mode = 'javascript';
+    } else if (contentType.indexOf('xml') >= 0) {
+      options.mode = 'xml';
+    } else {
+      options.mode = 'htmlmixed';
+    }
+  }
+  return CodeMirror.fromTextArea(textarea, options);
+};
+
+$(function(){
+  $(".request .body .content").each(function(i, el) {
+    el = $(el);
+    mirror(el.find("textarea")[0], el.data("content-type"), { "readOnly": true, "lineNumbers": true });
+  });
+});
diff --git a/lib/raddocs/app.rb b/lib/raddocs/app.rb
index 5608737..5761c4a 100644
--- a/lib/raddocs/app.rb
+++ b/lib/raddocs/app.rb
@@ -70,6 +70,14 @@ module Raddocs
     end

     helpers do
+      def content_security_policy_nonce
+        @content_security_policy_nonce ||= Rails.application.config.content_security_policy_nonce_generator.call(request)
+      end
+
+      def csp_meta_tag
+        %{<meta name="csp-nonce" content="#{content_security_policy_nonce}" />}
+      end
+
       def link_to(name, link)
         %{<a href="#{url_location}#{link}">#{name}</a>}
       end
diff --git a/lib/views/example.haml b/lib/views/example.haml
index 6f4bdf1..97fd9b4 100644
--- a/lib/views/example.haml
+++ b/lib/views/example.haml
@@ -3,31 +3,7 @@
     = haml :nav, locals: { index: index, api_name: api_name }

   .span10.main
-    :javascript
-      function mirror(textarea, contentType, options) {
-        $textarea = $(textarea);
-        if ($textarea.val() != '') {
-          if(contentType.indexOf('json') >= 0) {
-            $textarea.val(JSON.stringify(JSON.parse($textarea.val()), undefined, 2));
-            options.json = true;
-            options.mode = 'javascript';
-          } else if (contentType.indexOf('javascript') >= 0) {
-            options.mode = 'javascript';
-          } else if (contentType.indexOf('xml') >= 0) {
-            options.mode = 'xml';
-          } else {
-            options.mode = 'htmlmixed';
-          }
-        }
-        return CodeMirror.fromTextArea(textarea, options);
-      };
-
-      $(function(){
-        $(".request .body .content").each(function(i, el) {
-          el = $(el);
-          mirror(el.find("textarea")[0], el.data("content-type"), { "readOnly": true, "lineNumbers": true });
-        });
-      });
+    %script(nonce="#{content_security_policy_nonce}" src="#{url_location}/js/example.js")

     .nav-bar
       = link_to "&laquo; Back to Index", "/"
diff --git a/lib/views/layout.haml b/lib/views/layout.haml
index ec4067e..51517b9 100644
--- a/lib/views/layout.haml
+++ b/lib/views/layout.haml
@@ -1,17 +1,18 @@
 !!!
 %html
   %head
+    = csp_meta_tag
     %title= api_name

     - css_files.each do |file|
-      %link{:rel => "stylesheet", :href => file}
+      %link{:rel => "stylesheet", :href => file, :nonce => content_security_policy_nonce}

-    %script(src="#{url_location}/js/jquery-1-7-2.js")
-    %script(src="#{url_location}/js/codemirror.js")
-    %script(src="#{url_location}/js/mode/css/css.js")
-    %script(src="#{url_location}/js/mode/htmlmixed/htmlmixed.js")
-    %script(src="#{url_location}/js/mode/javascript/javascript.js")
-    %script(src="#{url_location}/js/mode/xml/xml.js")
+    %script(nonce="#{content_security_policy_nonce}" src="#{url_location}/js/jquery-1-7-2.js")
+    %script(nonce="#{content_security_policy_nonce}" src="#{url_location}/js/codemirror.js")
+    %script(nonce="#{content_security_policy_nonce}" src="#{url_location}/js/mode/css/css.js")
+    %script(nonce="#{content_security_policy_nonce}" src="#{url_location}/js/mode/htmlmixed/htmlmixed.js")
+    %script(nonce="#{content_security_policy_nonce}" src="#{url_location}/js/mode/javascript/javascript.js")
+    %script(nonce="#{content_security_policy_nonce}" src="#{url_location}/js/mode/xml/xml.js")

     :css
       td.required .name:after {
```

