### PR TITLE
Replaced deprecated 'File.exists?' with 'File.exist?'

### DIFF
--- a/lib/raddocs/app.rb
+++ b/lib/raddocs/app.rb
@@ -31,7 +31,7 @@ module Raddocs
     get "/custom-css/*" do
       file = "#{docs_dir}/styles/#{params[:splat][0]}"
 
-      if !File.exists?(file)
+      if !File.exist?(file)
         raise Sinatra::NotFound
       end
 
@@ -54,7 +54,7 @@ module Raddocs
     get "/*" do
       file = "#{docs_dir}/#{params[:splat][0]}.json"
 
-      if !File.exists?(file)
+      if !File.exist?(file)
         raise Sinatra::NotFound
       end
 


### PR DESCRIPTION
## Description
Replaced deprecated `File.exists?` with `File.exist?`

## Motivation
`File.exists?` was removed in Ruby 3.2, as it had been deprecated since Ruby 2.1 in favor of `File.exist?`.

See [Ruby 3.2 release notes](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) for more details.