### PR TITLE
[ASQ-1255] Updated sinatra dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     raddocs (2.3.0)
       haml (>= 4.0)
       json
-      sinatra
+      sinatra (~> 3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     raddocs (2.3.0)
       haml (>= 4.0)
       json
-      sinatra (~> 3.0)
+      sinatra (>= 3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/raddocs.gemspec
+++ b/raddocs.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "sinatra", "~> 2.0"
+  s.add_runtime_dependency "sinatra", "~> 3.0"
   s.add_runtime_dependency "haml", ">= 4.0"
   s.add_runtime_dependency "json"
 

--- a/raddocs.gemspec
+++ b/raddocs.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "sinatra", "~> 3.0"
+  s.add_runtime_dependency "sinatra", ">= 3.0"
   s.add_runtime_dependency "haml", ">= 4.0"
   s.add_runtime_dependency "json"
 


### PR DESCRIPTION
## Description
When upgrading ASQ's Ruby version to 3.4 in the scope of ticket [ASQ-1245](https://app.clickup.com/t/9006094761/ASQ-1245), the following script stopped working

```
bundle exec script/florida_app.rb
````

and so did the command below that calls the first command:
```
bundle exec foreman start
```

After some digging into the cause of the problem, we noticed that `sinatra`, which is called in the script, wouldn't start. This indicated that an older version of `sinatra`, likely to be incompatible with the new ruby version, could likely be the culprit.

Upon updating the `sinatra` dependency on `raddocs.gemspec` and specifying a version greater or equal to 3.0 on `Gemfile`, the problem was fixed.

## Motivation and Context
[ASQ-1255](https://app.clickup.com/t/9006094761/ASQ-1255) - Upgrade SmartLogic gems used in ASQ
[ASQ-1245](https://app.clickup.com/t/9006094761/ASQ-1245) - Upgrade Ruby from 3.2 to 3.4